### PR TITLE
fix: Regex matcher for renamed files

### DIFF
--- a/lua/jj-picker/init.lua
+++ b/lua/jj-picker/init.lua
@@ -21,7 +21,8 @@ function M.status()
 					hl = "SnacksPickerGitStatusDeleted"
 				elseif state == "R" then
 					hl = "SnacksPickerGitStatusRenamed"
-					file = string.match(text, "{.-=>%s*(.-)}")
+					local path, filename = string.match(text, "^(.*){.-=>%s*(.-)}")
+          file = path .. filename
 				end
 
 				local diff = vim.fn.system("jj diff " .. file .. " --no-pager --stat --git")


### PR DESCRIPTION
- Only returned the filename instead of the file path